### PR TITLE
Update de.json

### DIFF
--- a/modules/default/calendar/translations/de.json
+++ b/modules/default/calendar/translations/de.json
@@ -1,7 +1,7 @@
 {
   "TODAY": "Heute"
   , "TOMORROW": "Morgen"
-  , "RUNNING": "Endet in"
+  , "RUNNING": "Noch"
   , "LOADING": "Lade Termine &hellip;"
   , "EMPTY": "Keine Termine."
 }


### PR DESCRIPTION
"Noch" is grammatically better than "Endet in" for running events.